### PR TITLE
Add timed sfx and music to splash screen and main menu

### DIFF
--- a/DoubleExposure/game/screens.rpy
+++ b/DoubleExposure/game/screens.rpy
@@ -1031,9 +1031,11 @@ screen main_menu():
                 "bg dark room painting"
                 matrixcolor BrightnessMatrix(-.4)
                 pause 2.5
+                function play_darkroom_light_atl
                 "bg dark room painting red"
                 matrixcolor BrightnessMatrix(0)
                 pause 25
+                function play_darkroom_light_off_atl
                 "bg dark room painting"
                 matrixcolor BrightnessMatrix(-.4)
                 pause 4

--- a/DoubleExposure/game/script.rpy
+++ b/DoubleExposure/game/script.rpy
@@ -217,6 +217,7 @@ transform xhack: #no idea why I need this but we are like a day away from the en
 label splashscreen:
     scene black
     with Pause(.4)
+    play audio "porter-wail.mp3" noloop
     #show text "Created for the Spooktober Visual Novel Jam 2025 (this will be an image later)"
     show spooktoberlogo at center:
         truecenter zoom .5

--- a/DoubleExposure/game/sound.rpy
+++ b/DoubleExposure/game/sound.rpy
@@ -36,6 +36,18 @@ init python:
 
     def play_darkroom_light_atl(trans, st, at):
         play_darkroom_light()
+        renpy.music.play("piano-underscore-spook-1.mp3", channel="drone_1", fadein=18.0, loop=False, relative_volume=1.0)
+        renpy.music.play("piano-underscore-spook-2.mp3", channel="drone_2", fadein=24.0, loop=False, relative_volume=0.6)
+
+        return
+
+    def play_darkroom_light_off_atl(trans, st, at):
+        renpy.sound.play("breath-2.mp3", channel="sfx_2", relative_volume=0.5)
+        renpy.sound.play("low-thud-single.mp3", channel="sfx_3", relative_volume=0.1)
+        play_darkroom_light_off()
+        renpy.music.stop("drone_1")
+        renpy.music.stop("drone_2")
+        return
 
     def play_darkroom_light():
         renpy.sound.play("light-click.mp3", channel="sfx_1")
@@ -43,6 +55,7 @@ init python:
 
     def play_darkroom_light_off():
         renpy.sound.play("light-click-off.mp3", channel="sfx_1")
+        renpy.music.stop("ambiance_1")
 
     def play_slide_place(trans, st, at):
         renpy.sound.play(renpy.random.choice(slide_place_fx), channel="sfx_1")


### PR DESCRIPTION
Looks like there's some oddity when navigating menus from the main menu and returning to the main screen. It flashes the red darkroom with painting, then returns to no painting, 'bg dark room painting red', which I don't see configured anywhere, which is odd? @lilhungrybug @jdb175 